### PR TITLE
feat(app): allow pausing physics simulation

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -13,6 +13,7 @@ const JSON_URL =
 
 const App: FC = () => {
   const [data, setData] = useState<ICruiseResult>();
+  const [physicsSimulation, setPhysicsSimulation] = useState(true);
 
   const moduleDeps = useMemo(() => data && parseModuleDeps(data), [data]);
 
@@ -36,8 +37,10 @@ const App: FC = () => {
         moduleDeps={moduleDeps}
         filters={filters}
         onSubmit={setFilters}
+        physicsSimulation={physicsSimulation}
+        setPhysicsSimulation={setPhysicsSimulation}
       />
-      <DepGraph moduleDeps={moduleDeps} filters={filters} />
+      <DepGraph moduleDeps={moduleDeps} filters={filters} physicsSimulation={physicsSimulation} />
     </>
   );
 };

--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -40,7 +40,11 @@ const App: FC = () => {
         physicsSimulation={physicsSimulation}
         setPhysicsSimulation={setPhysicsSimulation}
       />
-      <DepGraph moduleDeps={moduleDeps} filters={filters} physicsSimulation={physicsSimulation} />
+      <DepGraph
+        moduleDeps={moduleDeps}
+        filters={filters}
+        physicsSimulation={physicsSimulation}
+      />
     </>
   );
 };

--- a/src/app/components/ControlPanel.tsx
+++ b/src/app/components/ControlPanel.tsx
@@ -16,9 +16,11 @@ type Props = {
   moduleDeps: ModuleDeps;
   filters: Filters;
   onSubmit?: (filters: Filters) => void;
+  physicsSimulation: boolean
+  setPhysicsSimulation: (enable: boolean) => void
 };
 
-const ControlPanel: FC<Props> = ({ moduleDeps, filters, onSubmit }) => {
+const ControlPanel: FC<Props> = ({ moduleDeps, filters, onSubmit, physicsSimulation, setPhysicsSimulation }) => {
   const modules = useMemo(() => getModules(moduleDeps), [moduleDeps]);
 
   const [targetModules, setTargetModules] = useState<string[]>(
@@ -80,6 +82,9 @@ const ControlPanel: FC<Props> = ({ moduleDeps, filters, onSubmit }) => {
           <Grid item>
             <Button variant="contained" color="primary" onClick={handleSubmit}>
               Render
+            </Button>
+            <Button variant="contained" color="secondary" onClick={() => setPhysicsSimulation(!physicsSimulation)}>
+              {physicsSimulation ? 'Stop' : 'Start'} physics simulation
             </Button>
           </Grid>
         </Grid>

--- a/src/app/components/ControlPanel.tsx
+++ b/src/app/components/ControlPanel.tsx
@@ -16,11 +16,17 @@ type Props = {
   moduleDeps: ModuleDeps;
   filters: Filters;
   onSubmit?: (filters: Filters) => void;
-  physicsSimulation: boolean
-  setPhysicsSimulation: (enable: boolean) => void
+  physicsSimulation: boolean;
+  setPhysicsSimulation: (enable: boolean) => void;
 };
 
-const ControlPanel: FC<Props> = ({ moduleDeps, filters, onSubmit, physicsSimulation, setPhysicsSimulation }) => {
+const ControlPanel: FC<Props> = ({
+  moduleDeps,
+  filters,
+  onSubmit,
+  physicsSimulation,
+  setPhysicsSimulation,
+}) => {
   const modules = useMemo(() => getModules(moduleDeps), [moduleDeps]);
 
   const [targetModules, setTargetModules] = useState<string[]>(
@@ -83,7 +89,11 @@ const ControlPanel: FC<Props> = ({ moduleDeps, filters, onSubmit, physicsSimulat
             <Button variant="contained" color="primary" onClick={handleSubmit}>
               Render
             </Button>
-            <Button variant="contained" color="secondary" onClick={() => setPhysicsSimulation(!physicsSimulation)}>
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={() => setPhysicsSimulation(!physicsSimulation)}
+            >
               {physicsSimulation ? 'Stop' : 'Start'} physics simulation
             </Button>
           </Grid>

--- a/src/app/components/DepGraph.tsx
+++ b/src/app/components/DepGraph.tsx
@@ -10,7 +10,7 @@ import { DepGraph, Filters, ModuleDeps } from '../utils/types';
 type Props = {
   moduleDeps: ModuleDeps;
   filters: Filters;
-  physicsSimulation: boolean
+  physicsSimulation: boolean;
 };
 
 type Stage = 'idle' | 'computing' | 'drawing';
@@ -65,7 +65,7 @@ const DepGraph: FC<Props> = ({ moduleDeps, filters, physicsSimulation }) => {
         containerRef.current,
         { edges, nodes },
         {
-          physics: {enabled: physicsSimulation},
+          physics: { enabled: physicsSimulation },
           nodes: {
             shape: 'image',
             shapeProperties: {
@@ -92,18 +92,18 @@ const DepGraph: FC<Props> = ({ moduleDeps, filters, physicsSimulation }) => {
         setStage('idle');
       });
 
-      setNetwork(newNetwork)
+      setNetwork(newNetwork);
     }
   }, [containerRef.current, graph]);
 
   useEffect(() => {
-    if(physicsSimulation){
-      network?.startSimulation()
+    if (physicsSimulation) {
+      network?.startSimulation();
     } else {
-      network?.stopSimulation()
+      network?.stopSimulation();
     }
-    network?.setOptions({physics: {enabled: physicsSimulation}})
-  }, [physicsSimulation, network])
+    network?.setOptions({ physics: { enabled: physicsSimulation } });
+  }, [physicsSimulation, network]);
 
   const handleTerminate = () => {
     if (worker != null) {

--- a/src/app/components/DepGraph.tsx
+++ b/src/app/components/DepGraph.tsx
@@ -10,11 +10,12 @@ import { DepGraph, Filters, ModuleDeps } from '../utils/types';
 type Props = {
   moduleDeps: ModuleDeps;
   filters: Filters;
+  physicsSimulation: boolean
 };
 
 type Stage = 'idle' | 'computing' | 'drawing';
 
-const DepGraph: FC<Props> = ({ moduleDeps, filters }) => {
+const DepGraph: FC<Props> = ({ moduleDeps, filters, physicsSimulation }) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const [graph, setGraph] = useState<DepGraph>();
@@ -22,6 +23,7 @@ const DepGraph: FC<Props> = ({ moduleDeps, filters }) => {
   const [worker, setWorker] = useState<Worker>();
 
   const [stage, setStage] = useState<Stage>('idle');
+  const [network, setNetwork] = useState<Network>();
 
   useEffect(() => {
     setStage('computing');
@@ -59,10 +61,11 @@ const DepGraph: FC<Props> = ({ moduleDeps, filters }) => {
         }),
       );
 
-      const network = new Network(
+      const newNetwork = new Network(
         containerRef.current,
         { edges, nodes },
         {
+          physics: {enabled: physicsSimulation},
           nodes: {
             shape: 'image',
             shapeProperties: {
@@ -85,11 +88,22 @@ const DepGraph: FC<Props> = ({ moduleDeps, filters }) => {
         },
       );
 
-      network.on('afterDrawing', () => {
+      newNetwork.on('afterDrawing', () => {
         setStage('idle');
       });
+
+      setNetwork(newNetwork)
     }
   }, [containerRef.current, graph]);
+
+  useEffect(() => {
+    if(physicsSimulation){
+      network?.startSimulation()
+    } else {
+      network?.stopSimulation()
+    }
+    network?.setOptions({physics: {enabled: physicsSimulation}})
+  }, [physicsSimulation, network])
 
   const handleTerminate = () => {
     if (worker != null) {


### PR DESCRIPTION
For big & complex graphs, the nodes can be unstable (see https://github.com/visjs/vis-network/issues/1636). This PR adds a button in the header to toggle the physics simulation.